### PR TITLE
jQuery 1.11 compatibility

### DIFF
--- a/app/views/time_loggers/_update_menu.html.erb
+++ b/app/views/time_loggers/_update_menu.html.erb
@@ -37,13 +37,11 @@ Refresh rate is taken from settings. If settings is invalid, 60 secs is used. Th
 <% end %>
 <%= javascript_tag do %>
 $(function() {
-  $('[data-remote][data-replace]')
-    .data('type', 'html')
-    .live('ajax:success', function(event, data) {
-      var $this = $(this);
-      $($this.data('replace')).html(data);
-      $this.trigger('ajax:replaced');
-    });
+  $(document).on('ajax:success', '[data-remote][data-replace]', function(event, data) {
+    var $this = $(this);
+    $($this.data('replace')).html(data);
+    $this.trigger('ajax:replaced');
+  });
 });
 <% end %>
 

--- a/init.rb
+++ b/init.rb
@@ -12,7 +12,7 @@ Redmine::Plugin.register :time_logger do
     name 'Time Logger'
     author 'Jim McAleer'
     description 'This is a plugin to help log time in Redmine.  The orignal author was Jérémie Delaitre.  I have decided not to follow the route the HicknHack software has gone because it''s too confusing and have spun this off of that.  I do plan on the option to have multiple loggers running for an individual user.'
-    version '0.5.1'
+    version '0.5.2'
 
     requires_redmine :version_or_higher => '1.1.0'
 


### PR DESCRIPTION
Timer in menu stopped working when I've upgraded redmine to version 2.6. The reason was the removal of `live` method in new jQuery (see http://api.jquery.com/live/). I've replaced `live` with `on` method.
