### PR TITLE
Rewrite data-replace handling and add support for data-with

### DIFF
--- a/app/views/time_loggers/_status_transition_list.html.erb
+++ b/app/views/time_loggers/_status_transition_list.html.erb
@@ -44,7 +44,7 @@
                                         :url => { :controller => '/time_loggers', :action => 'delete_status_transition', :transitions => transitions, :from_id => from },
                                         :html => { :class => 'icon icon-del' },
                                         :complete => "$('status-transition-list').replace(request.responseText);",
-					:remote => true
+                    :remote => true
                                     %>
                                 </td>
                             <% end %>
@@ -66,11 +66,15 @@
             <%= label_tag 'new-transition-to', l(:time_logger_settings_new_transition_to) %>
             <%= select_tag 'new-transition-to', new_transition_to_options %>
             <%= link_to l(:time_logger_settings_new_transition_add),
-                :url => { :controller => '/time_loggers', :action => 'add_status_transition', :transitions => transitions },
-                :with => "'from_id=' + $('new-transition-from').value + '&to_id=' + $('new-transition-to').value",
-                :html => { :class => 'icon icon-add' },
-                :complete => "$('status-transition-list').replace(request.responseText);",
-		:remote => true
+                {
+                    :controller => '/time_loggers',
+                    :action => 'add_status_transition',
+                    :transitions => transitions
+                },
+                "data-with" => "'from_id=' + $('#new-transition-from').val() + '&to_id=' + $('#new-transition-to').val()",
+                :class => 'icon icon-add',
+                'data-replace' => '#status-transition-list',
+                :remote => true
             %>
         </div>
     <% end %>

--- a/app/views/time_loggers/_update_menu.html.erb
+++ b/app/views/time_loggers/_update_menu.html.erb
@@ -25,7 +25,7 @@ $.ajax({
 	success: function(data){
 		$('#time-logger-menu').html(data);
 	},
-}); 
+});
 }
 <% end %>
 
@@ -34,16 +34,5 @@ This script periodically updates the time tracker menu item to reflect any chang
 Refresh rate is taken from settings. If settings is invalid, 60 secs is used. The minimum value is 5 secs.
 -->
 <%= javascript_tag "var timer = setInterval(updateTimeLoggerMenu, 60000);" %>
-<% end %>
-<%= javascript_tag do %>
-$(function() {
-  $('[data-remote][data-replace]')
-    .data('type', 'html')
-    .live('ajax:success', function(event, data) {
-      var $this = $(this);
-      $($this.data('replace')).html(data);
-      $this.trigger('ajax:replaced');
-    });
-});
-<% end %>
 
+<% end %>

--- a/assets/javascripts/time_logger.js
+++ b/assets/javascripts/time_logger.js
@@ -5,3 +5,27 @@ function updateElementIfChanged(id, newContent) {
     el = $(id);
     if (el.innerHTML != newContent) { el.update(newContent); }
 }
+
+$(function() {
+
+  // Support for data-with tag on elements with data-remote.
+  // Pass custom params to data-with to send them with the request.
+  $(document).on('ajax:beforeSend', '[data-remote][data-with]', function(event, xhr, settings){
+    var params = eval($(this).data('with'));
+    if (settings.url.match(/\?/)) {
+      settings.url = settings.url + '&' + params;
+    } else {
+      settings.url = settings.url + params;
+    }
+    return true;
+  });
+
+  // Support for data-replace tag on elements with data-remote.
+  // Pass an jQuery selector that should be replaced with the response from server.
+  $(document).on('ajax:success', '[data-remote][data-replace]', function(event, data) {
+    var $this = $(this);
+    $($this.data('replace')).html(data);
+    $this.trigger('ajax:replaced');
+    return true;
+  });
+});


### PR DESCRIPTION
Like statet in #6 jQuery dropped support for `.live()`.

This commit fixes this with a approach that is more like the original `.live()` behaviour of jQuery. It also watches for replaced DOM elements. Using only `.on` on the DOM element won't work, because the event is gone after the element got replaced. Using the approach in this commit fixes this and it works like expected. 

This also adds support for `data-with` attributes, that fixes the problems with #2 
