### PR TITLE
Redmine 3.0.0 compatibility

### DIFF
--- a/app/controllers/time_loggers_controller.rb
+++ b/app/controllers/time_loggers_controller.rb
@@ -4,17 +4,17 @@ class TimeLoggersController < ApplicationController
     def index
         if User.current.nil?
             @user_time_loggers = nil
-            @time_loggers = TimeLogger.find(:all)
+            @time_loggers = TimeLogger.all
         else
-            @user_time_loggers = TimeLogger.find(:all, :conditions => { :user_id => User.current.id })
-            @time_loggers = TimeLogger.find(:all, :conditions => [ 'user_id != ?', User.current.id ])
+            @user_time_loggers = TimeLogger.where(user_id: User.current.id)
+            @time_loggers = TimeLogger.where('user_id != ?', User.current.id)
         end
     end
 
     def start
         @time_logger = current
         if @time_logger.nil?
-            @issue = Issue.find(:first, :conditions => { :id => params[:issue_id] })
+            @issue = Issue.find_by_id(params[:issue_id])
             @time_logger = TimeLogger.new({ :issue_id => @issue.id })
 
             if @time_logger.save
@@ -75,7 +75,7 @@ class TimeLoggersController < ApplicationController
     end
 
     def delete
-        time_logger = TimeLogger.find(:first, :conditions => { :id => params[:id] })
+        time_logger = TimeLogger.find_by_id(params[:id])
         if !time_logger.nil?
             time_logger.destroy
             render :text => l(:time_logger_delete_success)
@@ -85,8 +85,8 @@ class TimeLoggersController < ApplicationController
     end
 
     def render_menu
-        @project = Project.find(:first, :conditions => { :id => params[:project_id] })
-        @issue = Issue.find(:first, :conditions => { :id => params[:issue_id] })
+        @project = Project.find_by_id(params[:project_id])
+        @issue = Issue.find_by_id(params[:issue_id])
         render :partial => 'embed_menu'
     end
 
@@ -107,12 +107,12 @@ class TimeLoggersController < ApplicationController
     protected
 
     def current
-        TimeLogger.find(:first, :conditions => { :user_id => User.current.id })
+        TimeLogger.find_by_user_id(User.current.id)
     end
 
     def apply_status_transition(issue)
         new_status_id = Setting.plugin_time_logger['status_transitions'][issue.status_id.to_s]
-        new_status = IssueStatus.find(:first, :conditions => { :id => new_status_id })
+        new_status = IssueStatus.find_by_id(new_status_id)
         if issue.new_statuses_allowed_to(User.current).include?(new_status)
             journal = @issue.init_journal(User.current, notes = l(:time_logger_label_transition_journal))
             @issue.status_id = new_status_id

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,14 +1,14 @@
 module ApplicationHelper
     def time_logger_for(user)
-        TimeLogger.find(:first, :conditions => { :user_id => user.id })
+        TimeLogger.find_by_user_id(user.id)
     end
 
     def status_from_id(status_id)
-        IssueStatus.find(:first, :conditions => { :id => status_id })
+        IssueStatus.find_by_id(status_id)
     end
 
     def statuses_list()
-        IssueStatus.find(:all)
+        IssueStatus.all
     end
 
     def to_status_options(statuses)
@@ -32,7 +32,7 @@ module ApplicationHelper
     def global_allowed_to?(user, action)
         return false if user.nil?
 
-        projects = Project.find(:all)
+        projects = Project.all
         for p in projects
             if user.allowed_to?(action, p)
                 return true

--- a/app/helpers/time_loggers_helper.rb
+++ b/app/helpers/time_loggers_helper.rb
@@ -1,9 +1,9 @@
 module TimeLoggersHelper
     def issue_from_id(issue_id)
-        Issue.find(:first, :conditions => { :id => issue_id })
+        Issue.find_by_id(issue_id)
     end
 
     def user_from_id(user_id)
-        User.find(:first, :conditions => { :id => user_id })
+        User.find_by_id(user_id)
     end
 end

--- a/app/models/time_logger.rb
+++ b/app/models/time_logger.rb
@@ -12,6 +12,8 @@ class TimeLogger < ActiveRecord::Base
     belongs_to :user
     has_one :issue
 
+    attr_accessible :issue_id
+
     validates_presence_of :issue_id
 
     def initialize(arguments = nil)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,12 +1,12 @@
 Rails.application.routes.draw do
-  match 'time_loggers/stop'   , :to => "time_loggers#stop"
-  match 'time_loggers/start'  , :to => "time_loggers#start"
-  match 'time_loggers/suspend', :to => "time_loggers#suspend"
-  match 'time_loggers/resume' , :to => "time_loggers#resume"
-  match 'time_loggers/render_menu', :to => "time_loggers#render_menu"
-  match 'time_loggers/add_status_transition', :to => "time_loggers#add_status_transition"
-  match 'time_loggers/delete_status_transition', :to => "time_loggers#delete_status_transition"
-  match 'time_loggers/show_report', :to => "time_loggers#show_report"
-  match 'time_loggers/delete', :to => "time_loggers#delete"
-  match 'time_loggers' , :to => "time_loggers#index"
+  match 'time_loggers/stop', :to => "time_loggers#stop", via: [:get, :post]
+  match 'time_loggers/start', :to => "time_loggers#start", via: [:get, :post]
+  match 'time_loggers/suspend', :to => "time_loggers#suspend", via: [:get, :post]
+  match 'time_loggers/resume', :to => "time_loggers#resume", via: [:get, :post]
+  match 'time_loggers/render_menu', :to => "time_loggers#render_menu", via: [:get, :post]
+  match 'time_loggers/add_status_transition', :to => "time_loggers#add_status_transition", via: [:get, :post]
+  match 'time_loggers/delete_status_transition', :to => "time_loggers#delete_status_transition", via: [:get, :post]
+  match 'time_loggers/show_report', :to => "time_loggers#show_report", via: [:get, :post]
+  match 'time_loggers/delete', :to => "time_loggers#delete", via: [:get, :post]
+  match 'time_loggers', :to => "time_loggers#index", via: [:get, :post]
 end


### PR DESCRIPTION
Removed deprecated syntax for finds, added methods to routes and added small fix to model to allow creation of new TimeLogger instances (time_loggers_controller.rb:18 was throwing an error).
Plugin is compatible with Redmine 2.6.2, though I didn't check if it is with older versions.