### PR TITLE
Set current user to issue when this starts

### DIFF
--- a/app/controllers/time_loggers_controller.rb
+++ b/app/controllers/time_loggers_controller.rb
@@ -19,6 +19,7 @@ class TimeLoggersController < ApplicationController
 
             if @time_logger.save
                 apply_status_transition(@issue) unless Setting.plugin_time_logger['status_transitions'] == nil
+                apply_auto_user_assign(@issue) unless Setting.plugin_time_logger['auto_user_assign'] == nil
                 render_menu
             else
                 flash[:error] = l(:start_time_logger_error)
@@ -70,10 +71,10 @@ class TimeLoggersController < ApplicationController
             hours = @time_logger.hours_spent.round(2)
             @time_logger.destroy
 
-            redirect_to :controller => 'issues', 
+            redirect_to :controller => 'issues',
                 :protocol => Setting.protocol,
-                :action => 'edit', 
-                :id => issue_id, 
+                :action => 'edit',
+                :id => issue_id,
                 :time_entry => { :hours => hours }
         end
     end
@@ -109,4 +110,12 @@ class TimeLoggersController < ApplicationController
             @issue.save
         end
     end
+
+    def apply_auto_user_assign(issue)
+      if @issue.assigned_to.class.name.downcase == "group"
+            @issue.assigned_to = User.current
+            @issue.save
+      end
+    end
+
 end

--- a/app/views/settings/_time_logger.html.erb
+++ b/app/views/settings/_time_logger.html.erb
@@ -8,6 +8,12 @@
         <%= text_field_tag 'settings[refresh_rate]', @settings['refresh_rate'], { :size => 4 } %>
         (<%= l(:time_logger_seconds) %>)
     </p>
+
+    <p>
+        <%= label_tag 'settings[auto_user_assign]', l(:time_logger_auto_user_assign) %>
+        <%= check_box_tag 'settings[auto_user_assign]', @settings['auto_user_assign'], @settings['auto_user_assign'] %>
+        <%= l(:time_logger_auto_user_assign_help) %>
+    </p>
 </div>
 
 <h3><%= l(:time_logger_settings_transition_title) %></h3>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,4 +40,5 @@ en:
   time_logger_settings_unknown_status: "Unknown status"
   time_logger_settings_zombie_transition: "zombie status transition"
   time_logger_zombie_legend: "zombie time tracker"
-
+  time_logger_auto_user_assign: "Auto assign user"
+  time_logger_auto_user_assign_help: "Assign the current user to the issue when this is assigned to a group"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -9,4 +9,5 @@ es:
   time_logger_hour_sym: ":"
   time_logger_refresh_rate: "Frecuencia de refresco"
   time_logger_seconds: "segundos"
-
+  time_logger_auto_user_assign: "Asignar usuario automáticamente"
+  time_logger_auto_user_assign_help: "Asignar usuario actual a la tarea cuando esta esté asignada a un grupo"

--- a/init.rb
+++ b/init.rb
@@ -20,7 +20,7 @@ Redmine::Plugin.register :time_logger do
 
     requires_redmine :version_or_higher => '1.1.0'
 
-    settings :default => { 'refresh_rate' => '60', 'status_transitions' => {} }, :partial => 'settings/time_logger'
+    settings :default => { 'refresh_rate' => '60', 'auto_user_assign'=>true, 'status_transitions' => {} }, :partial => 'settings/time_logger'
 
     permission :view_others_time_loggers, :time_loggers => :index
     permission :delete_others_time_loggers, :time_loggers => :delete


### PR DESCRIPTION
Issues assigned to groups can be assigned to current user automatically when timer starts. This behavior is configurable in module's settings.

This is usefull to proyects where issues are assigned to groups and each user pick an issue.
